### PR TITLE
Fix OAuth signature generation in validateRestApiAccess

### DIFF
--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -320,6 +320,10 @@ export async function validateRestApiAccess(httpClient, authManager) {
     // Get baseURL from httpClient for OAuth signature generation
     const baseURL = httpClient.defaults.baseURL;
 
+    if (!baseURL) {
+      throw new Error('httpClient baseURL is not configured');
+    }
+
     const results = [];
     for (const endpoint of endpoints) {
       try {

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -318,7 +318,7 @@ export async function validateRestApiAccess(httpClient, authManager) {
     ];
 
     // Get baseURL from httpClient for OAuth signature generation
-    const baseURL = httpClient.defaults.baseURL;
+    const baseURL = httpClient?.defaults?.baseURL;
 
     if (!baseURL) {
       throw new Error('httpClient baseURL is not configured');

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -317,10 +317,15 @@ export async function validateRestApiAccess(httpClient, authManager) {
       { path: '/feeds', name: 'Feeds' }
     ];
 
+    // Get baseURL from httpClient for OAuth signature generation
+    const baseURL = httpClient.defaults.baseURL;
+
     const results = [];
     for (const endpoint of endpoints) {
       try {
-        const headers = authManager.getAuthHeaders();
+        // Generate proper OAuth headers with full URL for signature
+        const fullUrl = `${baseURL}${endpoint.path}`;
+        const headers = authManager.getAuthHeaders('GET', fullUrl, { per_page: 1 });
         await httpClient.get(endpoint.path, {
           headers,
           params: { per_page: 1 }

--- a/src/tests/helpers.js
+++ b/src/tests/helpers.js
@@ -179,6 +179,7 @@ export class MockHttpClient {
     this.requests = [];
     this.responses = new Map();
     this.defaultResponse = new MockResponse();
+    this.defaults = { baseURL: 'https://test.example.com' };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix OAuth 1.0a signature generation in `validateRestApiAccess` function
- Resolve "REST API validation failed: undefined" error when using HTTP connections

## Problem
The `validateRestApiAccess` function was calling `getAuthHeaders()` without the required URL parameter for OAuth 1.0a signature generation. This caused authentication failures when using HTTP connections (which fall back to OAuth instead of Basic Auth).

## Steps to Reproduce
1. Clone and configure GravityMCP with HTTP base URL:
   ```bash
   git clone https://github.com/GravityKit/GravityMCP.git
   cd GravityMCP
   npm install
   cp .env.example .env
   # Configure .env with HTTP URL (e.g., http://localhost:31337)
   ```

2. Add to Claude Code:
   ```bash
   claude mcp add gravitymcp --scope user -- node /path/to/GravityMCP/src/index.js
   ```

3. Check MCP server status:
   ```bash
   claude mcp list
   ```

4. **Expected**: gravitymcp shows "✓ Connected"
5. **Actual**: gravitymcp shows "✗ Failed to connect" with error "REST API validation failed: undefined"

## Solution
- Get `baseURL` from `httpClient.defaults.baseURL`
- Construct full URL for each endpoint being validated
- Pass proper parameters (`method`, `url`, `params`) to `getAuthHeaders()`

## Test plan
- [x] Verified fix with `npm run check-env` on HTTP localhost connection
- [x] All 3 endpoints (forms, entries, feeds) now validate successfully with OAuth
- [x] Confirmed `claude mcp list` shows gravitymcp as connected after fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth signing now uses the full request URL derived from the client's base URL, improving signature accuracy and ensuring authenticated API calls validate correctly.
  * Validation now surfaces an error when a base URL is unavailable, preventing ambiguous requests and improving endpoint reliability.

* **Tests**
  * Test helpers now initialize a default mock client base URL for more consistent test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->